### PR TITLE
Show current song on menu

### DIFF
--- a/Spotify-Notifications/AppDelegate.h
+++ b/Spotify-Notifications/AppDelegate.h
@@ -25,6 +25,7 @@
 @property (strong, nonatomic) IBOutlet NSMenuItem *openSpotifyMenuItem;
 @property (strong, nonatomic) IBOutlet NSMenuItem *openLastFMMenu;
 @property (strong, nonatomic) IBOutlet NSMenuItem *openPreferences;
+@property (strong, nonatomic) IBOutlet NSMenuItem *currentSongMenuItem;
 
 //Preferences
 @property (assign) IBOutlet NSWindow *prefsWindow;
@@ -38,6 +39,7 @@
 - (IBAction)showPreferences:(NSMenuItem*)sender;
 
 - (IBAction)toggleStartup:(NSButton *)sender;
+- (IBAction)toggleShowCurrentSongMenu:(NSButton *)sender;
 
 - (IBAction)showHome:(id)sender;
 - (IBAction)showSource:(id)sender;

--- a/Spotify-Notifications/AppDelegate.m
+++ b/Spotify-Notifications/AppDelegate.m
@@ -193,6 +193,7 @@
 
 - (void)notPlaying {
     _openSpotifyMenuItem.title = @"Open Spotify (Not Playing)";
+    [_currentSongMenuItem setHidden:YES];
     
     [NSUserNotificationCenter.defaultUserNotificationCenter removeAllDeliveredNotifications];
 }
@@ -208,7 +209,7 @@
     if (spotify.playerState == SpotifyEPlSPlaying) {
         
         _openSpotifyMenuItem.title = @"Open Spotify (Playing)";
-
+        
         if (!_openLastFMMenu.isEnabled && [currentTrack.artist isNotEqualTo:NULL])
             [_openLastFMMenu setEnabled:YES];
         
@@ -217,6 +218,8 @@
             previousTrack = currentTrack;
             currentTrack = spotify.currentTrack;
         }
+        
+        [self showCurrentSongMenuIfNeeded];
         
         NSUserNotification *userNotification = [self userNotificationForCurrentTrack];
         [self deliverUserNotification:userNotification Force:NO];
@@ -227,6 +230,15 @@
         [self notPlaying];
     }
 
+}
+
+- (void)showCurrentSongMenuIfNeeded {
+    if ([currentTrack.artist isNotEqualTo:NULL]
+        && [currentTrack.name isNotEqualTo:NULL]
+        && [NSUserDefaults.standardUserDefaults boolForKey:kShowCurrentSongMenu]) {
+        [_currentSongMenuItem setHidden:NO];
+        _currentSongMenuItem.title = [NSString stringWithFormat:@"%@ - %@", currentTrack.name, currentTrack.artist];
+    }
 }
 
 #pragma mark - Preferences
@@ -267,6 +279,16 @@
     BOOL launchAtLogin = sender.state;
     [NSUserDefaults.standardUserDefaults setBool:launchAtLogin forKey:kLaunchAtLoginKey];
     [LaunchAtLogin setAppIsLoginItem:launchAtLogin];
+}
+
+- (IBAction)toggleShowCurrentSongMenu:(NSButton *)sender {
+    BOOL showCurrentSongMenu = sender.state;
+    if (spotify.playerState == SpotifyEPlSPlaying && showCurrentSongMenu) {
+        [self showCurrentSongMenuIfNeeded];
+        
+    } else {
+        [_currentSongMenuItem setHidden:YES];
+    }
 }
 
 #pragma mark - Preferences Info Buttons

--- a/Spotify-Notifications/SharedKeys.h
+++ b/Spotify-Notifications/SharedKeys.h
@@ -11,6 +11,7 @@
 #define kNotificationSoundKey @"notificationSound"
 #define kNotificationIncludeAlbumArtKey @"includeAlbumArt"
 #define kDisableWhenSpotifyHasFocusKey @"disableWhenSpotifyHasFocus"
+#define kShowCurrentSongMenu @"showCurrentSongMenu"
 
 #define kLaunchAtLoginKey @"startupSelection"
 #define kIconSelectionKey @"iconSelection"

--- a/Spotify-Notifications/UserDefaults.plist
+++ b/Spotify-Notifications/UserDefaults.plist
@@ -18,5 +18,7 @@
 	<true/>
 	<key>iconSelection</key>
 	<integer>1</integer>
+	<key>showCurrentSongMenu</key>
+	<false/>
 </dict>
 </plist>

--- a/Spotify-Notifications/en.lproj/MainMenu.xib
+++ b/Spotify-Notifications/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment version="1080" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -653,6 +653,7 @@
         <customObject id="494" customClass="AppDelegate">
             <connections>
                 <outlet property="albumArtToggle" destination="aBa-Hw-XwR" id="4BW-a9-ysb"/>
+                <outlet property="currentSongMenuItem" destination="pHu-qo-S1Q" id="HvV-bt-Xs1"/>
                 <outlet property="openLastFMMenu" destination="SZW-Od-Gwx" id="Lsx-Qa-lnL"/>
                 <outlet property="openPreferences" destination="61H-gV-eIG" id="6Ub-JI-ndP"/>
                 <outlet property="openSpotifyMenuItem" destination="ac7-hp-JP8" id="DVL-ln-Aph"/>
@@ -670,6 +671,10 @@
                     <connections>
                         <action selector="openSpotify:" target="494" id="sis-Yi-Idj"/>
                     </connections>
+                </menuItem>
+                <menuItem title="Song - Artist" hidden="YES" enabled="NO" indentationLevel="1" id="pHu-qo-S1Q">
+                    <attributedString key="attributedTitle"/>
+                    <modifierMask key="keyEquivalentModifierMask"/>
                 </menuItem>
                 <menuItem title="Last.fm" enabled="NO" id="SZW-Od-Gwx">
                     <menu key="submenu" title="Last.fm" id="a8M-Lg-29f">
@@ -712,14 +717,14 @@
         </menu>
         <window title="Spotify Notifications Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="XjB-tk-5rO">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
-            <rect key="contentRect" x="131" y="165" width="414" height="366"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
+            <rect key="contentRect" x="131" y="165" width="414" height="391"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="778"/>
             <view key="contentView" id="yf3-aQ-pSq">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="366"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="391"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4SO-dX-Mel">
-                        <rect key="frame" x="18" y="330" width="99" height="18"/>
+                        <rect key="frame" x="18" y="355" width="99" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Notifications" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="4bB-WV-Nwp">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -730,7 +735,7 @@
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OAZ-Ww-EPz">
-                        <rect key="frame" x="38" y="299" width="147" height="18"/>
+                        <rect key="frame" x="38" y="324" width="147" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Notify on play/pause" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rvB-JZ-Q1f">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -742,7 +747,7 @@
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kJu-oN-gdE">
-                        <rect key="frame" x="38" y="274" width="165" height="18"/>
+                        <rect key="frame" x="38" y="299" width="165" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Show only current song" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="TBZ-eB-ay4">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -758,7 +763,7 @@
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NH5-X4-wGw">
-                        <rect key="frame" x="38" y="249" width="165" height="18"/>
+                        <rect key="frame" x="38" y="274" width="165" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Sound" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="4P2-LF-4Wc">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -774,11 +779,11 @@
                         </connections>
                     </button>
                     <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="YHb-hV-LYS">
-                        <rect key="frame" x="12" y="321" width="390" height="5"/>
+                        <rect key="frame" x="12" y="346" width="390" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </box>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aBa-Hw-XwR">
-                        <rect key="frame" x="38" y="224" width="165" height="18"/>
+                        <rect key="frame" x="38" y="249" width="165" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Include album art" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Fze-BV-aPM">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -794,7 +799,7 @@
                         </connections>
                     </button>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SQv-uh-10R">
-                        <rect key="frame" x="38" y="199" width="212" height="18"/>
+                        <rect key="frame" x="38" y="224" width="212" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Disable when Spotify has focus" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="UAJ-z0-EAL">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -810,7 +815,7 @@
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ciN-aU-Ao4">
-                        <rect key="frame" x="38" y="109" width="94" height="17"/>
+                        <rect key="frame" x="38" y="107" width="94" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Menu bar icon:" id="J1v-0s-9HJ">
                             <font key="font" metaFont="system"/>
@@ -819,7 +824,7 @@
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vwp-Bk-YZI">
-                        <rect key="frame" x="10" y="166" width="52" height="17"/>
+                        <rect key="frame" x="10" y="191" width="52" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="General" id="SyE-UP-gfk">
                             <font key="font" metaFont="system"/>
@@ -828,7 +833,7 @@
                         </textFieldCell>
                     </textField>
                     <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="36k-RY-ycT">
-                        <rect key="frame" x="136" y="103" width="152" height="26"/>
+                        <rect key="frame" x="136" y="101" width="152" height="26"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="D3F-Wn-llx">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -853,7 +858,7 @@
                         </connections>
                     </popUpButton>
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="whs-lL-9F4">
-                        <rect key="frame" x="38" y="133" width="176" height="18"/>
+                        <rect key="frame" x="38" y="158" width="176" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="check" title="Launch at system startup" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="g6q-xR-pOH">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -864,11 +869,11 @@
                         </connections>
                     </button>
                     <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="45B-g4-7kq">
-                        <rect key="frame" x="12" y="155" width="390" height="5"/>
+                        <rect key="frame" x="12" y="180" width="390" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </box>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iYs-fy-aKp">
-                        <rect key="frame" x="38" y="83" width="167" height="17"/>
+                        <rect key="frame" x="38" y="81" width="167" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show current song hotkey:" id="ioa-gS-kBC">
                             <font key="font" metaFont="system"/>
@@ -877,7 +882,7 @@
                         </textFieldCell>
                     </textField>
                     <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zbi-2N-Pgf" customClass="MASShortcutView">
-                        <rect key="frame" x="211" y="82" width="165" height="19"/>
+                        <rect key="frame" x="211" y="80" width="165" height="19"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HhP-Bg-IV0">
@@ -928,9 +933,21 @@
                             <action selector="showSource:" target="494" id="0eV-Gj-17K"/>
                         </connections>
                     </button>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WPN-HF-pBB">
+                        <rect key="frame" x="38" y="133" width="214" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Show current song in the menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="pdB-fX-CLw">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="toggleShowCurrentSongMenu:" target="494" id="Gi1-qa-0kA"/>
+                            <binding destination="5Si-TY-24i" name="value" keyPath="values.showCurrentSongMenu" id="yl0-es-7a3"/>
+                        </connections>
+                    </button>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="629" y="298"/>
+            <point key="canvasLocation" x="629" y="310.5"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="5Si-TY-24i"/>
     </objects>

--- a/contributors.md
+++ b/contributors.md
@@ -11,3 +11,4 @@
 - Jonathan Tien ([Jonathan Tien](https://github.com/ricefield/))
 - Randall Bruder ([randybruder](https://github.com/randybruder/))
 - Seb Jachec ([sebj](https://github.com/sebj))
+- Leonardo Barros ([leobarrospereira](https://github.com/leobarrospereira))


### PR DESCRIPTION
Just add an extra item on menu when Spotify is playing to show the current song (name - artist).

<img width="336" alt="screen shot 2018-02-28 at 17 43 38" src="https://user-images.githubusercontent.com/6533999/36800466-e9ca7b10-1caf-11e8-93cd-00f8a8f0704d.png">

It's an optional feature, the user can define in the preferences to show it or not. Default is NO.

<img width="421" alt="screen shot 2018-03-06 at 17 16 27" src="https://user-images.githubusercontent.com/6533999/37043877-28c1cc86-2162-11e8-98fc-6b8bd6545d62.png">

